### PR TITLE
Allow batch restarting

### DIFF
--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -304,6 +304,8 @@ if ( ! class_exists( 'WP_Background_Process' ) ) {
 
 					if ( false !== $task ) {
 						$batch->data[ $key ] = $task;
+						// Restart batch.
+						break;
 					} else {
 						unset( $batch->data[ $key ] );
 					}


### PR DESCRIPTION
Hey @A5hleyRich - thanks for sharing and maintaining this nice piece of work!

I was wondering what is the intended behaviour when a task returns data other than `false` for re-processing.

Currently it looks like it is queued at the end. Is this intended?

In this PR I am including a modification that would make the "exited" task re-start in its current position in the queue, which might be desirable if one wants to reliably keep track of a resource (memory, time or other) at task level, and be able to restart it at will.

I'm not sure if this would be a good standard behaviour, but I'd be interested in your thoughts.

Thanks!

PS: This is NOT intended for merging, but to illustrate my question with an example. The provided filters can be used to achieve a similar behaviour without overriding/modifying the `handle` method.
