### PR TITLE
Add filter async_http_request_args

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ function wpbp_http_request_args( $r, $url ) {
 
 	return $r;
 }
-add_filter( 'http_request_args', 'wpbp_http_request_args', 10, 2);
+add_filter( 'async_http_request_args', 'wpbp_http_request_args', 10, 2);
 ```
 
 ## License

--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -84,6 +84,16 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 			$url  = add_query_arg( $this->get_query_args(), $this->get_query_url() );
 			$args = $this->get_post_args();
 
+			/**
+			 * Filters the arguments used in an async request.
+			 *
+			 * @since 1.0.2
+			 *
+			 * @param array  $args An array of HTTP request arguments.
+			 * @param string $url  The request URL.
+			 */
+			$args = apply_filters( 'async_http_request_args', $args, $url );
+
 			return wp_remote_post( esc_url_raw( $url ), $args );
 		}
 


### PR DESCRIPTION
I think this is a generally useful filter but is important when adding basic auth. In the readme example basic auth is added to all external requests not just async requests which is probably a security problem.  