### PR TITLE
Add a note about process instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Instantiate your process:
 
 `$this->example_process = new WP_Example_Process();`
 
+**Note:** You must instantiate your process unconditionally. All requests should do this, even if nothing is pushed to the queue.
+
 Push items to the queue:
 
 ```php


### PR DESCRIPTION
Instantiation should happen unconditionally. If you only instantiate on-demand when you're pushing to the queue, it won't work.

I was confused about this. I had this code:

```php
public function add_items( array $items = [] ) {
	$job = new MyJob();

	foreach ( $items as $item ) {
		$job->push_to_queue( $item );
	};

	$job->save()->dispatch();
}
```

This did not work, because on requests where I was not calling `add_items()`, `MyJob()` wasn't being instantiated.