### PR TITLE
Add filters for `wp_remote_post()` arguments.

### DIFF
--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -97,10 +97,17 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 				return $this->query_args;
 			}
 
-			return array(
+			$args = array(
 				'action' => $this->identifier,
 				'nonce'  => wp_create_nonce( $this->identifier ),
 			);
+
+			/**
+			 * Filters the post arguments used during an async request.
+			 *
+			 * @param array $url
+			 */
+			return apply_filters( $this->identifier . '_query_args', $args );
 		}
 
 		/**
@@ -113,7 +120,14 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 				return $this->query_url;
 			}
 
-			return admin_url( 'admin-ajax.php' );
+			$url = admin_url( 'admin-ajax.php' );
+
+			/**
+			 * Filters the post arguments used during an async request.
+			 *
+			 * @param string $url
+			 */
+			return apply_filters( $this->identifier . '_query_url', $url );
 		}
 
 		/**
@@ -126,13 +140,20 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 				return $this->post_args;
 			}
 
-			return array(
+			$args = array(
 				'timeout'   => 0.01,
 				'blocking'  => false,
 				'body'      => $this->data,
 				'cookies'   => $_COOKIE,
 				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
 			);
+
+			/**
+			 * Filters the post arguments used during an async request.
+			 *
+			 * @param array $args
+			 */
+			return apply_filters( $this->identifier . '_post_args', $args );
 		}
 
 		/**


### PR DESCRIPTION
I've had occasion to change the default arguments passed by `WP_Async_Request` to `wp_remote_post()` both in plugins and on client sites. It's currently possible to do this, sort of, by setting the `$post_args` etc properties on the request object. (I assume that this customization is the purpose of the `property_exists()` checks.) But this is hard to implement, and it plays especially poorly with the post `body`, since it ought to pull dynamically from `$this->data` but generally `data` is only set just before `dispatch()` is called.

It would be hugely helpful to have filters like the ones suggested here. Thanks for considering!