### PR TITLE
Added check for is_process_running() in dispatch()

### DIFF
--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -69,6 +69,12 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * @return void
 	 */
 	public function dispatch() {
+
+		if ( $this->is_process_running() ) {
+			// Process already running.
+			return true;
+		}
+
 		// Schedule the cron healthcheck.
 		$this->schedule_event();
 


### PR DESCRIPTION
Instead of checking `$this->is_process_running()` in `maybe_handle()`, it makes more sense for performance to check before dispatching the async request at all.

In our case, using WP Background Processing to handle incoming webhooks from CRMs, we're using 

`$process->push_to_queue( $webhook );`
`$process->save()->dispatch();`

to store each webhook. So each incoming requests spawned a new async request, and most of them then died immediately because the process was already running.. With 20+ requests in a minute, we'd start to get timeout errors.

This little change has reduced the server load by about 90% and now we can easily handle 100+ incoming webhooks in a minute 😎 