### PR TITLE
Port forward new features and improvements from WP Offload Media

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -36,15 +36,7 @@
 
 		<!-- TODO: Maybe fix -->
 		<exclude name="WordPress.WP.CronInterval.ChangeDetected"/>
-		<exclude name="WordPress.WP.AlternativeFunctions.rand_rand"/>
 		<exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery"/>
-
-		<!-- TODO: Should fix -->
-		<exclude name="WordPress.DB.PreparedSQL.InterpolatedNotPrepared"/>
-		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
-		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
-		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
-		<exclude name="Generic.Commenting.DocComment.SpacingAfter"/>
 	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ __Requires PHP 5.6+__
 
 The recommended way to install this library in your project is by loading it through Composer:
 
-```
+```shell
 composer require deliciousbrains/wp-background-processing
 ```
 
@@ -30,6 +30,11 @@ class WP_Example_Request extends WP_Async_Request {
 	/**
 	 * @var string
 	 */
+	protected $prefix = 'my_plugin';
+
+	/**
+	 * @var string
+	 */
 	protected $action = 'example_request';
 
 	/**
@@ -45,44 +50,61 @@ class WP_Example_Request extends WP_Async_Request {
 }
 ```
 
-##### `protected $action`
+#### `protected $prefix`
+
+Should be set to a unique prefix associated with your plugin, theme, or site's custom function prefix.
+
+#### `protected $action`
 
 Should be set to a unique name.
 
-##### `protected function handle()`
+#### `protected function handle()`
 
 Should contain any logic to perform during the non-blocking request. The data passed to the request will be accessible via `$_POST`.
 
-##### Dispatching Requests
+#### Dispatching Requests
 
 Instantiate your request:
 
-`$this->example_request = new WP_Example_Request();`
+```php
+$this->example_request = new WP_Example_Request();
+```
 
 Add data to the request if required:
 
-`$this->example_request->data( array( 'value1' => $value1, 'value2' => $value2 ) );`
+```php
+$this->example_request->data( array( 'value1' => $value1, 'value2' => $value2 ) );
+```
 
 Fire off the request:
 
-`$this->example_request->dispatch();`
+```php
+$this->example_request->dispatch();
+```
 
 Chaining is also supported:
 
-`$this->example_request->data( array( 'data' => $data ) )->dispatch();`
+```php
+$this->example_request->data( array( 'data' => $data ) )->dispatch();
+```
 
 ### Background Process
 
-Background processes work in a similar fashion to async requests, but they allow you to queue tasks. Items pushed onto the queue will be processed in the background once the queue has been dispatched. Queues will also scale based on available server resources, so higher end servers will process more items per batch. Once a batch has completed, the next batch will start instantly.
+Background processes work in a similar fashion to async requests, but they allow you to queue tasks. Items pushed onto the queue will be processed in the background once the queue has been saved and dispatched. Queues will also scale based on available server resources, so higher end servers will process more items per batch. Once a batch has completed, the next batch will start instantly.
 
 Health checks run by default every 5 minutes to ensure the queue is running when queued items exist. If the queue has failed it will be restarted.
 
-Queues work on a first in first out basis, which allows additional items to be pushed to the queue even if it’s already processing.
+Queues work on a first in first out basis, which allows additional items to be pushed to the queue even if it’s already processing. Saving a new batch of queued items and dispatching while another background processing instance is already running will result in the dispatch shortcutting out and the existing instance eventually picking up the new items and processing them when it is their turn.
 
 Extend the `WP_Background_Process` class:
 
 ```php
 class WP_Example_Process extends WP_Background_Process {
+
+	/**
+	 * @var string
+	 */
+	protected $prefix = 'my_plugin';
 
 	/**
 	 * @var string
@@ -122,23 +144,29 @@ class WP_Example_Process extends WP_Background_Process {
 }
 ```
 
-##### `protected $action`
+#### `protected $prefix`
+
+Should be set to a unique prefix associated with your plugin, theme, or site's custom function prefix.
+
+#### `protected $action`
 
 Should be set to a unique name.
 
-##### `protected function task( $item )`
+#### `protected function task( $item )`
 
 Should contain any logic to perform on the queued item. Return `false` to remove the item from the queue or return `$item` to push it back onto the queue for further processing. If the item has been modified and is pushed back onto the queue the current state will be saved before the batch is exited.
 
-##### `protected function complete()`
+#### `protected function complete()`
 
 Optionally contain any logic to perform once the queue has completed.
 
-##### Dispatching Processes
+#### Dispatching Processes
 
 Instantiate your process:
 
-`$this->example_process = new WP_Example_Process();`
+```php
+$this->example_process = new WP_Example_Process();
+```
 
 **Note:** You must instantiate your process unconditionally. All requests should do this, even if nothing is pushed to the queue.
 
@@ -152,7 +180,91 @@ foreach ( $items as $item ) {
 
 Save and dispatch the queue:
 
-`$this->example_process->save()->dispatch();`
+```php
+$this->example_process->save()->dispatch();
+```
+
+#### Background Process Status
+
+A background process can be processing, paused, cancelled, or none of the above (not started or has completed).
+
+##### Processing
+
+To check whether a background process is currently handling a queue of items use `is_processing()`.
+
+```php
+if ( $this->example_process->is_processing() ) {
+    // Do something because background process is running, e.g. add notice in admin UI.
+}
+```
+
+##### Paused
+
+You can pause a background process with `pause()`.
+
+```php
+$this->example_process->pause();
+```
+
+The currently processing batch will continue until it either completes or reaches the time or memory limit. At that point it'll unlock the process and either complete the batch if the queue is empty, or perform a dispatch that will result in the handler removing the healthcheck cron and firing a "paused" action.
+
+To check whether a background process is currently paused use `is_paused()`.
+
+```php
+if ( $this->example_process->is_paused() ) {
+    // Do something because background process is paused, e.g. add notice in admin UI.
+}
+```
+
+You can perform an action in response to background processing being paused by handling the "paused" action for the background process's identifier ($prefix + $action).
+
+```php
+add_action( 'my_plugin_example_process_paused', function() {
+    // Do something because background process is paused, e.g. add notice in admin UI.
+});
+```
+
+You can resume a background process with `resume()`.
+
+```php
+$this->example_process->resume();
+```
+
+You can perform an action in response to background processing being resumed by handling the "resumed" action for the background process's identifier ($prefix + $action).
+
+```php
+add_action( 'my_plugin_example_process_resumed', function() {
+    // Do something because background process is resumed, e.g. add notice in admin UI.
+});
+```
+
+##### Cancelled
+
+You can cancel a background process with `cancel()`.
+
+```php
+$this->example_process->cancel();
+```
+
+The currently processing batch will continue until it either completes or reaches the time or memory limit. At that point it'll unlock the process and either complete the batch if the queue is empty, or perform a dispatch that will result in the handler removing the healthcheck cron, deleting all batches of queued items and firing a "cancelled" action.
+
+To check whether a background process is currently cancelled use `is_cancelled()`.
+
+```php
+if ( $this->example_process->is_cancelled() ) {
+    // Do something because background process is cancelled, e.g. add notice in admin UI.
+}
+```
+
+You can perform an action in response to background processing being cancelled by handling the "cancelled" action for the background process's identifier ($prefix + $action).
+
+```php
+add_action( 'my_plugin_example_process_cancelled', function() {
+    // Do something because background process is paused, e.g. add notice in admin UI.
+});
+```
+
+The "cancelled" action fires once the queue has been cleared down and cancelled status removed. After which `is_cancelled()` will no longer be true as the background process is now dormant.
 
 ### BasicAuth
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,18 @@ add_action( 'my_plugin_example_process_cancelled', function() {
 
 The "cancelled" action fires once the queue has been cleared down and cancelled status removed. After which `is_cancelled()` will no longer be true as the background process is now dormant.
 
+##### Active
+
+To check whether a background process has queued items, is processing, is paused, or is cancelling, use `is_active()`.
+
+```php
+if ( $this->example_process->is_active() ) {
+    // Do something because background process is active, e.g. add notice in admin UI.
+}
+```
+
+If a background process is not active, then it either has not had anything queued yet and not started, or has finished processing all queued items.
+
 ### BasicAuth
 
 If your site is behind BasicAuth, both async requests and background processes will fail to complete. This is because WP Background Processing relies on the [WordPress HTTP API](https://developer.wordpress.org/plugins/http-api/), which requires you to attach your BasicAuth credentials to requests. The easiest way to do this is using the following filter:

--- a/README.md
+++ b/README.md
@@ -186,7 +186,17 @@ $this->example_process->save()->dispatch();
 
 #### Background Process Status
 
-A background process can be processing, paused, cancelled, or none of the above (not started or has completed).
+A background process can be queued, processing, paused, cancelled, or none of the above (not started or has completed).
+
+##### Queued
+
+To check whether a background process has queued items use `is_queued()`.
+
+```php
+if ( $this->example_process->is_queued() ) {
+    // Do something because background process has queued items, e.g. add notice in admin UI.
+}
+```
 
 ##### Processing
 

--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -158,6 +158,8 @@ abstract class WP_Async_Request {
 	 * Maybe handle a dispatched request.
 	 *
 	 * Check for correct nonce and pass to handler.
+	 *
+	 * @return void|mixed
 	 */
 	public function maybe_handle() {
 		// Don't lock up other requests while processing.
@@ -167,7 +169,27 @@ abstract class WP_Async_Request {
 
 		$this->handle();
 
-		wp_die();
+		return $this->maybe_wp_die();
+	}
+
+	/**
+	 * Should the process exit with wp_die?
+	 *
+	 * @param mixed $return What to return if filter says don't die, default is null.
+	 *
+	 * @return void|mixed
+	 */
+	protected function maybe_wp_die( $return = null ) {
+		/**
+		 * Should wp_die be used?
+		 *
+		 * @returns bool
+		 */
+		if ( apply_filters( $this->identifier . '_wp_die', true ) ) {
+			wp_die();
+		}
+
+		return $return;
 	}
 
 	/**

--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -142,8 +142,8 @@ abstract class WP_Async_Request {
 			'timeout'   => 0.01,
 			'blocking'  => false,
 			'body'      => $this->data,
-			'cookies'   => $_COOKIE,
-			'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
+			'cookies'   => $_COOKIE, // Passing cookies ensures request is performed as initiating user.
+			'sslverify' => apply_filters( 'https_local_ssl_verify', false ), // Local requests, fine to pass false.
 		);
 
 		/**

--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -183,7 +183,7 @@ abstract class WP_Async_Request {
 		/**
 		 * Should wp_die be used?
 		 *
-		 * @returns bool
+		 * @return bool
 		 */
 		if ( apply_filters( $this->identifier . '_wp_die', true ) ) {
 			wp_die();

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -83,7 +83,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * @return array|WP_Error|false HTTP Response array, WP_Error on failure, or false if not attempted.
 	 */
 	public function dispatch() {
-		if ( $this->is_process_running() ) {
+		if ( $this->is_processing() ) {
 			// Process already running.
 			return false;
 		}
@@ -288,7 +288,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 		// Don't lock up other requests while processing.
 		session_write_close();
 
-		if ( $this->is_process_running() ) {
+		if ( $this->is_processing() ) {
 			// Background process already running.
 			return $this->maybe_wp_die();
 		}
@@ -353,8 +353,22 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 *
 	 * Check whether the current process is already running
 	 * in a background process.
+	 *
+	 * @return bool
+	 *
+	 * @deprecated 1.1.0 Superseded.
+	 * @see        is_processing()
 	 */
 	protected function is_process_running() {
+		return $this->is_processing();
+	}
+
+	/**
+	 * Is the background process currently running?
+	 *
+	 * @return bool
+	 */
+	public function is_processing() {
 		if ( get_site_transient( $this->identifier . '_process_lock' ) ) {
 			// Process already running.
 			return true;
@@ -659,7 +673,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * and data exists in the queue.
 	 */
 	public function handle_cron_healthcheck() {
-		if ( $this->is_process_running() ) {
+		if ( $this->is_processing() ) {
 			// Background process already running.
 			exit;
 		}

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -252,6 +252,21 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	}
 
 	/**
+	 * Is queued?
+	 *
+	 * @return bool
+	 */
+	public function is_queued() {
+		$batch = $this->get_batch();
+
+		if ( empty( $batch ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Generate key for a batch.
 	 *
 	 * Generates a unique key based on microtime. Queue items are

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -257,13 +257,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * @return bool
 	 */
 	public function is_queued() {
-		$batch = $this->get_batch();
-
-		if ( empty( $batch ) ) {
-			return false;
-		}
-
-		return true;
+		return ! $this->is_queue_empty();
 	}
 
 	/**
@@ -349,27 +343,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * @return bool
 	 */
 	protected function is_queue_empty() {
-		global $wpdb;
-
-		$table  = $wpdb->options;
-		$column = 'option_name';
-
-		if ( is_multisite() ) {
-			$table  = $wpdb->sitemeta;
-			$column = 'meta_key';
-		}
-
-		$key = $wpdb->esc_like( $this->identifier . '_batch_' ) . '%';
-
-		$sql = '
-			SELECT COUNT(*)
-			FROM ' . $table . '
-			WHERE ' . $column . ' LIKE %s
-		';
-
-		$count = $wpdb->get_var( $wpdb->prepare( $sql, $key ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-
-		return ! ( $count > 0 );
+		return empty( $this->get_batch() );
 	}
 
 	/**

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -290,31 +290,33 @@ abstract class WP_Background_Process extends WP_Async_Request {
 
 		if ( $this->is_process_running() ) {
 			// Background process already running.
-			wp_die();
+			return $this->maybe_wp_die();
 		}
 
 		if ( $this->is_cancelled() ) {
 			$this->clear_scheduled_event();
 			$this->delete_all();
-			wp_die();
+
+			return $this->maybe_wp_die();
 		}
 
 		if ( $this->is_paused() ) {
 			$this->clear_scheduled_event();
 			$this->paused();
-			wp_die();
+
+			return $this->maybe_wp_die();
 		}
 
 		if ( $this->is_queue_empty() ) {
 			// No data to process.
-			wp_die();
+			return $this->maybe_wp_die();
 		}
 
 		check_ajax_referer( $this->identifier, 'nonce' );
 
 		$this->handle();
 
-		wp_die();
+		return $this->maybe_wp_die();
 	}
 
 	/**
@@ -534,7 +536,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 			$this->complete();
 		}
 
-		wp_die();
+		return $this->maybe_wp_die();
 	}
 
 	/**

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -108,6 +108,9 @@ abstract class WP_Background_Process extends WP_Async_Request {
 			update_site_option( $key, $this->data );
 		}
 
+		// Clean out data so that new data isn't prepended with closed session's data.
+		$this->data = array();
+
 		return $this;
 	}
 

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -267,6 +267,15 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	}
 
 	/**
+	 * Is the tool currently active, e.g. starting, working, paused or cleaning up?
+	 *
+	 * @return bool
+	 */
+	public function is_active() {
+		return $this->is_queued() || $this->is_processing() || $this->is_paused() || $this->is_cancelled();
+	}
+
+	/**
 	 * Generate key for a batch.
 	 *
 	 * Generates a unique key based on microtime. Queue items are

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -36,7 +36,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	/**
 	 * Cron_hook_identifier
 	 *
-	 * @var mixed
+	 * @var string
 	 * @access protected
 	 */
 	protected $cron_hook_identifier;
@@ -44,10 +44,24 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	/**
 	 * Cron_interval_identifier
 	 *
-	 * @var mixed
+	 * @var string
 	 * @access protected
 	 */
 	protected $cron_interval_identifier;
+
+	/**
+	 * The status set when process is cancelling.
+	 *
+	 * @var int
+	 */
+	const STATUS_CANCELLED = 1;
+
+	/**
+	 * The status set when process is paused or pausing.
+	 *
+	 * @var int;
+	 */
+	const STATUS_PAUSED = 2;
 
 	/**
 	 * Initiate new background process.
@@ -144,6 +158,100 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	}
 
 	/**
+	 * Delete entire job queue.
+	 */
+	public function delete_all() {
+		$batches = $this->get_batches();
+
+		foreach ( $batches as $batch ) {
+			$this->delete( $batch->key );
+		}
+
+		delete_site_option( $this->get_status_key() );
+
+		$this->cancelled();
+	}
+
+	/**
+	 * Cancel job on next batch.
+	 */
+	public function cancel() {
+		update_site_option( $this->get_status_key(), self::STATUS_CANCELLED );
+
+		// Just in case the job was paused at the time.
+		$this->dispatch();
+	}
+
+	/**
+	 * Has the process been cancelled?
+	 *
+	 * @return bool
+	 */
+	public function is_cancelled() {
+		$status = get_site_option( $this->get_status_key(), 0 );
+
+		if ( absint( $status ) === self::STATUS_CANCELLED ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Called when background process has been cancelled.
+	 */
+	protected function cancelled() {
+		do_action( $this->identifier . '_cancelled' );
+	}
+
+	/**
+	 * Pause job on next batch.
+	 */
+	public function pause() {
+		update_site_option( $this->get_status_key(), self::STATUS_PAUSED );
+	}
+
+	/**
+	 * Is the job paused?
+	 *
+	 * @return bool
+	 */
+	public function is_paused() {
+		$status = get_site_option( $this->get_status_key(), 0 );
+
+		if ( absint( $status ) === self::STATUS_PAUSED ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Called when background process has been paused.
+	 */
+	protected function paused() {
+		do_action( $this->identifier . '_paused' );
+	}
+
+	/**
+	 * Resume job.
+	 */
+	public function resume() {
+		delete_site_option( $this->get_status_key() );
+
+		$this->schedule_event();
+		$this->dispatch();
+		$this->resumed();
+	}
+
+	/**
+	 * Called when background process has been resumed.
+	 */
+	protected function resumed() {
+		do_action( $this->identifier . '_resumed' );
+	}
+
+	/**
 	 * Generate key for a batch.
 	 *
 	 * Generates a unique key based on microtime. Queue items are
@@ -155,10 +263,19 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * @return string
 	 */
 	protected function generate_key( $length = 64, $key = 'batch' ) {
-		$unique  = md5( microtime() . rand() );
+		$unique  = md5( microtime() . wp_rand() );
 		$prepend = $this->identifier . '_' . $key . '_';
 
 		return substr( $prepend . $unique, 0, $length );
+	}
+
+	/**
+	 * Get the status key.
+	 *
+	 * @return string
+	 */
+	protected function get_status_key() {
+		return $this->identifier . '_status';
 	}
 
 	/**
@@ -173,6 +290,18 @@ abstract class WP_Background_Process extends WP_Async_Request {
 
 		if ( $this->is_process_running() ) {
 			// Background process already running.
+			wp_die();
+		}
+
+		if ( $this->is_cancelled() ) {
+			$this->clear_scheduled_event();
+			$this->delete_all();
+			wp_die();
+		}
+
+		if ( $this->is_paused() ) {
+			$this->clear_scheduled_event();
+			$this->paused();
 			wp_die();
 		}
 
@@ -206,11 +335,13 @@ abstract class WP_Background_Process extends WP_Async_Request {
 
 		$key = $wpdb->esc_like( $this->identifier . '_batch_' ) . '%';
 
-		$count = $wpdb->get_var( $wpdb->prepare( "
+		$sql = '
 			SELECT COUNT(*)
-			FROM $table
-			WHERE $column LIKE %s
-		", $key ) );
+			FROM ' . $table . '
+			WHERE ' . $column . ' LIKE %s
+		';
+
+		$count = $wpdb->get_var( $wpdb->prepare( $sql, $key ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		return ! ( $count > 0 );
 	}
@@ -346,6 +477,22 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	protected function handle() {
 		$this->lock_process();
 
+		/**
+		 * Number of seconds to sleep between batches. Defaults to 0 seconds, minimum 0.
+		 *
+		 * @param int $seconds
+		 */
+		$throttle_seconds = max(
+			0,
+			apply_filters(
+				$this->identifier . '_seconds_between_batches',
+				apply_filters(
+					$this->prefix . '_seconds_between_batches',
+					0
+				)
+			)
+		);
+
 		do {
 			$batch = $this->get_batch();
 
@@ -358,16 +505,22 @@ abstract class WP_Background_Process extends WP_Async_Request {
 					unset( $batch->data[ $key ] );
 				}
 
+				// Keep the batch up to date while processing it.
+				if ( ! empty( $batch->data ) ) {
+					$this->update( $batch->key, $batch->data );
+				}
+
+				// Let the server breathe a little.
+				sleep( $throttle_seconds );
+
 				if ( $this->time_exceeded() || $this->memory_exceeded() ) {
 					// Batch limits reached.
 					break;
 				}
 			}
 
-			// Update or delete current batch.
-			if ( ! empty( $batch->data ) ) {
-				$this->update( $batch->key, $batch->data );
-			} else {
+			// Delete current batch if fully processed.
+			if ( empty( $batch->data ) ) {
 				$this->delete( $batch->key );
 			}
 		} while ( ! $this->time_exceeded() && ! $this->memory_exceeded() && ! $this->is_queue_empty() );
@@ -451,8 +604,19 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * performed, or, call parent::complete().
 	 */
 	protected function complete() {
+		delete_site_option( $this->get_status_key() );
+
 		// Remove the cron healthcheck job from the cron schedule.
 		$this->clear_scheduled_event();
+
+		$this->completed();
+	}
+
+	/**
+	 * Called when background process has completed.
+	 */
+	protected function completed() {
+		do_action( $this->identifier . '_completed' );
 	}
 
 	/**
@@ -465,16 +629,22 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * @return mixed
 	 */
 	public function schedule_cron_healthcheck( $schedules ) {
-		$interval = apply_filters( $this->identifier . '_cron_interval', 5 );
+		$interval = apply_filters( $this->cron_interval_identifier, 5 );
 
 		if ( property_exists( $this, 'cron_interval' ) ) {
-			$interval = apply_filters( $this->identifier . '_cron_interval', $this->cron_interval );
+			$interval = apply_filters( $this->cron_interval_identifier, $this->cron_interval );
 		}
 
-		// Adds an "Every NNN Minutes" schedule to the existing cron schedules.
-		$schedules[ $this->identifier . '_cron_interval' ] = array(
+		if ( 1 === $interval ) {
+			$display = __( 'Every Minute' );
+		} else {
+			$display = sprintf( __( 'Every %d Minutes' ), $interval );
+		}
+
+		// Adds an "Every NNN Minute(s)" schedule to the existing cron schedules.
+		$schedules[ $this->cron_interval_identifier ] = array(
 			'interval' => MINUTE_IN_SECONDS * $interval,
-			'display'  => sprintf( __( 'Every %d Minutes' ), $interval ),
+			'display'  => $display,
 		);
 
 		return $schedules;
@@ -498,9 +668,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 			exit;
 		}
 
-		$this->handle();
-
-		exit;
+		$this->dispatch();
 	}
 
 	/**
@@ -528,15 +696,11 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 *
 	 * Stop processing queue items, clear cron job and delete batch.
 	 *
+	 * @deprecated 1.1.0 Superseded.
+	 * @see        cancel()
 	 */
 	public function cancel_process() {
-		if ( ! $this->is_queue_empty() ) {
-			$batch = $this->get_batch();
-
-			$this->delete( $batch->key );
-
-			wp_clear_scheduled_hook( $this->cron_hook_identifier );
-		}
+		$this->cancel();
 	}
 
 	/**

--- a/tests/Test_WP_Background_Process.php
+++ b/tests/Test_WP_Background_Process.php
@@ -205,4 +205,23 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 		$this->wpbp->pause();
 		$this->assertTrue( $this->wpbp->is_paused() );
 	}
+
+	/**
+	 * Test delete.
+	 *
+	 * @return void
+	 */
+	public function test_delete() {
+		$this->wpbp->push_to_queue( 'wibble' );
+		$this->wpbp->save();
+		$this->assertCount( 1, $this->wpbp->get_batches() );
+		$this->wpbp->push_to_queue( 'wobble' );
+		$this->wpbp->save();
+		$this->assertCount( 2, $this->wpbp->get_batches() );
+		$first_batch = $this->executeWPBPMethod( 'get_batch' );
+		$this->wpbp->delete( $first_batch->key );
+		$this->assertCount( 1, $this->wpbp->get_batches() );
+		$second_batch = $this->executeWPBPMethod( 'get_batch' );
+		$this->assertNotEquals( $first_batch, $second_batch, '2nd batch returned as 1st deleted' );
+	}
 }

--- a/tests/Test_WP_Background_Process.php
+++ b/tests/Test_WP_Background_Process.php
@@ -88,6 +88,24 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test save.
+	 *
+	 * @return void
+	 */
+	public function test_save() {
+		$this->assertClassHasAttribute( 'data', 'WP_Background_Process', 'class has data property' );
+		$this->assertEmpty( $this->getWPBPProperty( 'data' ) );
+		$this->assertEmpty( $this->wpbp->get_batches(), 'no batches until save' );
+
+		$this->wpbp->push_to_queue( 'wibble' );
+		$this->assertNotEmpty( $this->getWPBPProperty( 'data' ) );
+		$this->assertEquals( array( 'wibble' ), $this->getWPBPProperty( 'data' ) );
+		$this->wpbp->save();
+		$this->assertEmpty( $this->getWPBPProperty( 'data' ), 'data emptied after save' );
+		$this->assertNotEmpty( $this->wpbp->get_batches(), 'batches exist after save' );
+	}
+
+	/**
 	 * Test get_batches.
 	 *
 	 * @return void

--- a/tests/Test_WP_Background_Process.php
+++ b/tests/Test_WP_Background_Process.php
@@ -224,4 +224,20 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 		$second_batch = $this->executeWPBPMethod( 'get_batch' );
 		$this->assertNotEquals( $first_batch, $second_batch, '2nd batch returned as 1st deleted' );
 	}
+
+	/**
+	 * Test delete_all.
+	 *
+	 * @return void
+	 */
+	public function test_delete_all() {
+		$this->wpbp->push_to_queue( 'wibble' );
+		$this->wpbp->save();
+		$this->assertCount( 1, $this->wpbp->get_batches() );
+		$this->wpbp->push_to_queue( 'wobble' );
+		$this->wpbp->save();
+		$this->assertCount( 2, $this->wpbp->get_batches() );
+		$this->wpbp->delete_all();
+		$this->assertCount( 0, $this->wpbp->get_batches() );
+	}
 }

--- a/tests/Test_WP_Background_Process.php
+++ b/tests/Test_WP_Background_Process.php
@@ -207,6 +207,21 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test resume.
+	 *
+	 * @return void
+	 */
+	public function test_resume() {
+		$this->wpbp->push_to_queue( 'wibble' );
+		$this->wpbp->save();
+		$this->assertFalse( $this->wpbp->is_paused() );
+		$this->wpbp->pause();
+		$this->assertTrue( $this->wpbp->is_paused() );
+		$this->wpbp->resume();
+		$this->assertFalse( $this->wpbp->is_paused() );
+	}
+
+	/**
 	 * Test delete.
 	 *
 	 * @return void

--- a/tests/Test_WP_Background_Process.php
+++ b/tests/Test_WP_Background_Process.php
@@ -154,7 +154,7 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'stdClass', $second_batch );
 		$this->assertEquals( $first_batch, $second_batch, 'same 1st batch returned until deleted' );
 
-		$this->executeWPBPMethod( 'delete', $first_batch->key );
+		$this->wpbp->delete( $first_batch->key );
 		$second_batch = $this->executeWPBPMethod( 'get_batch' );
 		$this->assertNotEmpty( $second_batch );
 		$this->assertInstanceOf( 'stdClass', $second_batch );

--- a/tests/Test_WP_Background_Process.php
+++ b/tests/Test_WP_Background_Process.php
@@ -179,4 +179,17 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 		$this->assertNotEquals( $first_batch, $second_batch, '2nd batch returned as 1st deleted' );
 		$this->assertEquals( array( 'more wibble' ), $second_batch->data );
 	}
+
+	/**
+	 * Test cancel.
+	 *
+	 * @return void
+	 */
+	public function test_cancel() {
+		$this->wpbp->push_to_queue( 'wibble' );
+		$this->wpbp->save();
+		$this->assertFalse( $this->wpbp->is_cancelled() );
+		$this->wpbp->cancel();
+		$this->assertTrue( $this->wpbp->is_cancelled() );
+	}
 }

--- a/tests/Test_WP_Background_Process.php
+++ b/tests/Test_WP_Background_Process.php
@@ -255,4 +255,24 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 		$this->wpbp->delete_all();
 		$this->assertCount( 0, $this->wpbp->get_batches() );
 	}
+
+	/**
+	 * Test update.
+	 *
+	 * @return void
+	 */
+	public function test_update() {
+		$this->wpbp->push_to_queue( 'wibble' );
+		$this->wpbp->save();
+		$this->assertCount( 1, $this->wpbp->get_batches() );
+		$this->wpbp->push_to_queue( 'wobble' );
+		$this->wpbp->save();
+		$this->assertCount( 2, $this->wpbp->get_batches() );
+		$first_batch = $this->executeWPBPMethod( 'get_batch' );
+		$this->wpbp->update( $first_batch->key, array( 'Wibble wobble all day long!' ) );
+		$this->assertCount( 2, $this->wpbp->get_batches() );
+		$updated_batch = $this->executeWPBPMethod( 'get_batch' );
+		$this->assertNotEquals( $first_batch, $updated_batch, 'fetched updated batch different to 1st fetch' );
+		$this->assertEquals( array( 'Wibble wobble all day long!' ), $updated_batch->data, 'fetched updated batch has expected data' );
+	}
 }

--- a/tests/Test_WP_Background_Process.php
+++ b/tests/Test_WP_Background_Process.php
@@ -499,4 +499,26 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 		$this->assertCount( 0, $this->wpbp->get_batches() );
 		$this->assertFalse( $this->wpbp->is_processing(), 'not left processing on complete' );
 	}
+
+	/**
+	 * Test is_queued.
+	 *
+	 * @return void
+	 */
+	public function test_is_queued() {
+		$this->assertFalse( $this->wpbp->is_queued(), 'nothing queued until save' );
+
+		$this->wpbp->push_to_queue( 'wibble' );
+		$this->assertFalse( $this->wpbp->is_queued(), 'nothing queued until save' );
+
+		$this->wpbp->save();
+		$this->assertTrue( $this->wpbp->is_queued(), 'queued items exist' );
+
+		$this->wpbp->push_to_queue( 'wobble' );
+		$this->wpbp->save();
+		$this->assertTrue( $this->wpbp->is_queued(), 'queued items exist' );
+
+		$this->wpbp->delete_all();
+		$this->assertFalse( $this->wpbp->is_queued(), 'queue emptied' );
+	}
 }

--- a/tests/Test_WP_Background_Process.php
+++ b/tests/Test_WP_Background_Process.php
@@ -192,4 +192,17 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 		$this->wpbp->cancel();
 		$this->assertTrue( $this->wpbp->is_cancelled() );
 	}
+
+	/**
+	 * Test pause.
+	 *
+	 * @return void
+	 */
+	public function test_pause() {
+		$this->wpbp->push_to_queue( 'wibble' );
+		$this->wpbp->save();
+		$this->assertFalse( $this->wpbp->is_paused() );
+		$this->wpbp->pause();
+		$this->assertTrue( $this->wpbp->is_paused() );
+	}
 }


### PR DESCRIPTION
Resolves #7 
Resolves #28 
Resolves #61 

This PR ports forward improvements made to WP Offload Media (WP Background Processing was originally extracted from it).

Improvements include:

* Incomplete batch records are updated more often for better visibility.
* It is now possible to throttle the processing to give the server a breather after each batch is processed.
* It is now possible to pause, resume and cancel a background process.
* It is now possible to check whether a background process has queued items, is running, is pausing or being cancelled, otherwise known as active.
* A background process now fires actions when it has been paused, resumed, cancelled or completed.
* It is now possible to fully clear all saved queue items.
* Adding multiple batches in the same PHP process no longer results in batches prepended with the data of previously added batches.
* Various minor improvements and updated README.