### PR TITLE
Make sure that non-blocking request params are preserved

### DIFF
--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -86,10 +86,11 @@ abstract class WP_Async_Request {
 	}
 
 	/**
- 	 * Persist non-blocking request args
-   	 * 
-     	 * @return array
-       	 */
+	 * Persist non-blocking request args.
+	 *
+	 * @param array $request_args Post request params.
+	 * @return array
+	 */
 	public function persist_request_args( $request_args ) {
 		$args = $this->get_post_args();
 		if ( isset( $args['timeout'] ) ) {

--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -94,7 +94,7 @@ abstract class WP_Async_Request {
 	public function persist_request_args( $request_args ) {
 		$args = $this->get_post_args();
 		if ( isset( $args['timeout'] ) ) {
-			$request_args['timeout'] = $args;
+			$request_args['timeout'] = $args['timeout'];
 		}
 		if ( isset( $args['blocking'] ) ) {
 			$request_args['blocking'] = $args['blocking'];

--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -81,9 +81,26 @@ abstract class WP_Async_Request {
 	public function dispatch() {
 		$url  = add_query_arg( $this->get_query_args(), $this->get_query_url() );
 		$args = $this->get_post_args();
-
+		add_filter( 'http_request_args', array( $this, 'persist_request_args' ), 99 );
 		return wp_remote_post( esc_url_raw( $url ), $args );
 	}
+
+	/**
+ 	 * Persist non-blocking request args
+   	 * 
+     	 * @return array
+       	 */
+	public function persist_request_args( $request_args ) {
+		$args = $this->get_post_args();
+		if ( isset( $args['timeout'] ) ) {
+			$request_args['timeout'] = $args;
+		}
+		if ( isset( $args['blocking'] ) ) {
+			$request_args['blocking'] = $args['blocking'];
+		}
+		return $request_args;
+	}
+
 
 	/**
 	 * Get query args.


### PR DESCRIPTION
## The problem

I created a background process that was getting correctly processed, but had the very annoying habit of never closing the connection back to the browser, so everytime I fired it the server would timeout.

So, from the admin panel I would click on the button that created a query, added items to the queue and then saved and dispatched the background process, but kept on loading until I got a 504 error -- I expected that all of that should happen very fast and then show an "ok, queue started" message to the user.

After a long time checking that the task was fine and then step-debugging, I noticed that everything worked fine right until just before the "dispatch", so something should happen the `wp_remote_post()` call from wp-background-processing.php ([around these line](https://github.com/deliciousbrains/wp-background-processing/blob/d5ef95cecba7f792ddca3e3bd70ebfb90dc4996d/classes/wp-async-request.php#L85))

Finally, the issue was caused by a filter hook from another plugin that modified the "timeout" parameter on the POST request, particularly using the [http_request_timeout filter](https://developer.wordpress.org/reference/hooks/http_request_timeout/) that was setting the timeout to 5 minutes.

## Proposal

I propose to add a filter hook to make sure that non-blocking request parameters are preserved, in order to avoid hitting server timeouts which I think its one of the main features of this library.

The proposed change would respect other request parameters, and would use the same parameters defined for the purposes of this same library, cherry picking the "timeout" and "blocking" params from the get_post_args method.