### PR TITLE
Ensure task processing cleanly pauses or cancels as soon as possible

### DIFF
--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -527,8 +527,8 @@ abstract class WP_Background_Process extends WP_Async_Request {
 				// Let the server breathe a little.
 				sleep( $throttle_seconds );
 
-				if ( $this->time_exceeded() || $this->memory_exceeded() ) {
-					// Batch limits reached.
+				// Batch limits reached, or pause or cancel request.
+				if ( $this->time_exceeded() || $this->memory_exceeded() || $this->is_paused() || $this->is_cancelled() ) {
 					break;
 				}
 			}
@@ -537,7 +537,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 			if ( empty( $batch->data ) ) {
 				$this->delete( $batch->key );
 			}
-		} while ( ! $this->time_exceeded() && ! $this->memory_exceeded() && ! $this->is_queue_empty() );
+		} while ( ! $this->time_exceeded() && ! $this->memory_exceeded() && ! $this->is_queue_empty() && ! $this->is_paused() && ! $this->is_cancelled() );
 
 		$this->unlock_process();
 


### PR DESCRIPTION
At present, it is possible for a task handler to recognise that pause or cancel has been requested, return back to the library's `WP_Background_Process::handle()` function as incomplete, but continue to get re-called until timeout because `handle()` does not check that pause or cancel has been requested.

This change updates `handle()` to check whether pause or cancel has been requested before going around to retry processing batches if timeouts have not been reached.