### PR TITLE
Increase timeout for non-blocking request.

### DIFF
--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -139,7 +139,7 @@ abstract class WP_Async_Request {
 		}
 
 		$args = array(
-			'timeout'   => 0.01,
+			'timeout'   => 5,
 			'blocking'  => false,
 			'body'      => $this->data,
 			'cookies'   => $_COOKIE, // Passing cookies ensures request is performed as initiating user.


### PR DESCRIPTION
When timeout is too small, request could not be sent at all. Actual value of timeout is not significant, as wp_remote_post() returns control immediately after sending of non-blocking request.