### PR TITLE
Addressing a way around #81, not perfect, but allow overriding nonce …

### DIFF
--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -165,7 +165,23 @@ abstract class WP_Async_Request {
 		// Don't lock up other requests while processing.
 		session_write_close();
 
-		check_ajax_referer( $this->identifier, 'nonce' );
+		$nonce_check = check_ajax_referer( $this->identifier, 'nonce' );
+		/**
+		 * Allow overriding the nonce check for ajax calls
+		 *
+		 * @param bool $nonce_check
+		 * @param string $action
+		 * @param string $identifier
+		 * @return bool
+		 */
+		$nonce_check = apply_filters( 'wpbp_nonce_check_override', $nonce_check, $this->action, $this->identifier );
+		if( ! $nonce_check ) {
+			if ( wp_doing_ajax() ) {
+				wp_die( -1, 403 );
+			} else {
+				die( '-1' );
+			}
+		}
 
 		$this->handle();
 

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -330,7 +330,25 @@ abstract class WP_Background_Process extends WP_Async_Request {
 			return $this->maybe_wp_die();
 		}
 
-		check_ajax_referer( $this->identifier, 'nonce' );
+		$nonce_check = check_ajax_referer( $this->identifier, 'nonce', false );
+
+		/**
+		 * Allow overriding the nonce check for ajax calls
+		 *
+		 * @param bool $nonce_check
+		 * @param string $action
+		 * @param string $identifier
+		 * @return bool
+		 */
+		$nonce_check = apply_filters( 'wpbp_nonce_check_override', $nonce_check, $this->action, $this->identifier );
+
+		if( ! $nonce_check ) {
+			if ( wp_doing_ajax() ) {
+				wp_die( -1, 403 );
+			} else {
+				die( '-1' );
+			}
+		}
 
 		$this->handle();
 


### PR DESCRIPTION
…values on a action/identifier basis

How to use it, for example, I have a class that extends \WP_Async_Request that I want to call via REST. The class has the following $action property:

```
protected $action = 'swpr-ingest-generator';
```

To override the nonce check, with this PR I can simply add:

```
add_filter( 'wpbp_nonce_check_override', function( $nonce_result, $action, $identifier ){
    if ( 'swpr-ingest-generator' === $action ) {
        $nonce_result = true;
    }
    return $nonce_result;
}, 10, 3 );
```

Note, I do not need the third parameter, but it's there for completeness, in case someone needs to filter by identifier.

This works in my use-case test.