### PR TITLE
Ensure 1st healthcheck runs in the future, not immediately before dispatch

### DIFF
--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -651,6 +651,25 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	}
 
 	/**
+	 * Get the cron healthcheck interval in minutes.
+	 *
+	 * Default is 5 minutes, minimum is 1 minute.
+	 *
+	 * @return int
+	 */
+	public function get_cron_interval() {
+		$interval = 5;
+
+		if ( property_exists( $this, 'cron_interval' ) ) {
+			$interval = $this->cron_interval;
+		}
+
+		$interval = apply_filters( $this->cron_interval_identifier, $interval );
+
+		return is_int( $interval ) && 0 < $interval ? $interval : 5;
+	}
+
+	/**
 	 * Schedule the cron healthcheck job.
 	 *
 	 * @access public
@@ -660,11 +679,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * @return mixed
 	 */
 	public function schedule_cron_healthcheck( $schedules ) {
-		$interval = apply_filters( $this->cron_interval_identifier, 5 );
-
-		if ( property_exists( $this, 'cron_interval' ) ) {
-			$interval = apply_filters( $this->cron_interval_identifier, $this->cron_interval );
-		}
+		$interval = $this->get_cron_interval();
 
 		if ( 1 === $interval ) {
 			$display = __( 'Every Minute' );
@@ -707,7 +722,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 */
 	protected function schedule_event() {
 		if ( ! wp_next_scheduled( $this->cron_hook_identifier ) ) {
-			wp_schedule_event( time(), $this->cron_interval_identifier, $this->cron_hook_identifier );
+			wp_schedule_event( time() + ( $this->get_cron_interval() * MINUTE_IN_SECONDS ), $this->cron_interval_identifier, $this->cron_hook_identifier );
 		}
 	}
 

--- a/tests/Test_WP_Background_Process.php
+++ b/tests/Test_WP_Background_Process.php
@@ -5,7 +5,7 @@
  * @package WP-Background-Processing
  */
 
- require_once __DIR__ . '/fixtures/Test_Batch_Data.php';
+require_once __DIR__ . '/fixtures/Test_Batch_Data.php';
 
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -208,31 +208,31 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 		$this->assertEquals( array( $batch_data_object ), $this->getWPBPProperty( 'data' ) );
 		$this->wpbp->save();
 		$third_batch = $this->executeWPBPMethod( 'get_batch' );
-		$this->assertCount( 1,  $third_batch->data );
+		$this->assertCount( 1, $third_batch->data );
 		$this->assertInstanceOf( Test_Batch_Data::class, $third_batch->data[0] );
 
 		// Explicitly set allowed classes to Test_Batch_Data.
 		$this->setWPBPProperty( 'allowed_batch_data_classes', array( Test_Batch_Data::class ) );
 		$third_batch = $this->executeWPBPMethod( 'get_batch' );
-		$this->assertCount( 1,  $third_batch->data );
+		$this->assertCount( 1, $third_batch->data );
 		$this->assertInstanceOf( Test_Batch_Data::class, $third_batch->data[0] );
 
 		// Allow a different class.
 		$this->setWPBPProperty( 'allowed_batch_data_classes', array( stdClass::class ) );
 		$third_batch = $this->executeWPBPMethod( 'get_batch' );
-		$this->assertCount( 1,  $third_batch->data );
+		$this->assertCount( 1, $third_batch->data );
 		$this->assertInstanceOf( __PHP_Incomplete_Class::class, $third_batch->data[0] );
 
 		// Disallow all classes.
 		$this->setWPBPProperty( 'allowed_batch_data_classes', false );
 		$third_batch = $this->executeWPBPMethod( 'get_batch' );
-		$this->assertCount( 1,  $third_batch->data );
+		$this->assertCount( 1, $third_batch->data );
 		$this->assertInstanceOf( __PHP_Incomplete_Class::class, $third_batch->data[0] );
 
 		// Allow everything.
 		$this->setWPBPProperty( 'allowed_batch_data_classes', true );
 		$third_batch = $this->executeWPBPMethod( 'get_batch' );
-		$this->assertCount( 1,  $third_batch->data );
+		$this->assertCount( 1, $third_batch->data );
 		$this->assertInstanceOf( Test_Batch_Data::class, $third_batch->data[0] );
 	}
 
@@ -641,5 +641,32 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 		$this->assertTrue( $this->wpbp->is_active(), 'cancelling, so still active' );
 		$this->wpbp->maybe_handle();
 		$this->assertFalse( $this->wpbp->is_active(), 'cancel handled, queue emptied, so no longer active' );
+	}
+
+	/**
+	 * Test get_cron_interval.
+	 *
+	 * @return void
+	 */
+	public function test_get_cron_interval() {
+		// Default value.
+		$this->assertEquals( 5, $this->wpbp->get_cron_interval() );
+
+		// Override via property (usually on subclass).
+		$this->wpbp->cron_interval = 3;
+		$this->assertEquals( 3, $this->wpbp->get_cron_interval() );
+
+		// Override via filter.
+		$callback = function ( $interval ) {
+			return 1;
+		};
+		add_filter( $this->getWPBPProperty( 'identifier' ) . '_cron_interval', $callback );
+		$this->assertEquals( 1, $this->wpbp->get_cron_interval() );
+
+		remove_filter( $this->getWPBPProperty( 'identifier' ) . '_cron_interval', $callback );
+		$this->assertEquals( 3, $this->wpbp->get_cron_interval() );
+
+		unset( $this->wpbp->cron_interval );
+		$this->assertEquals( 5, $this->wpbp->get_cron_interval() );
 	}
 }


### PR DESCRIPTION
Fixes a problem whereby as soon as the healthcheck cron event was scheduled, it ran straight away, even before the background process was dispatched.

This resulted in the cron event starting the background process dispatch chain and the `dispatch()` itself often being redundant.

Now the healthcheck cron is scheduled to start at the allotted cron interval in the future, continuing to reschedule itself at that interval from then on until the background process completes or is cancelled.

The filter that fires to set the cron interval now only fires once rather than potentially twice if the `WP_Background_Process` subclass has a `cron_interval` property added.

A `get_cron_interval()` method has been added that enables determining what the background process's healthcheck cron interval is.