### PR TITLE
Updated CODEOWNERS to use jira key

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @deliciousbrains/deli-eng
 
-#jira:[18802] is where issues related to this repository should be ticketed]
+#jira:DELI is where issues related to this repository should be ticketed]


### PR DESCRIPTION
Standardizing CODEOWNERS to use jira key instead of project id