### PR TITLE
Add Chain ID for better control of background process lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ vendor: composer.json
 .PHONY: clean
 clean:
 	rm -rf vendor
-	rm -f tests/.phpunit.result.cache
+	rm -f tests/.phpunit.result.cache .phpunit.result.cache

--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -101,9 +101,9 @@ abstract class WP_Async_Request {
 		);
 
 		/**
-		 * Filters the post arguments used during an async request.
+		 * Filters the query arguments used during an async request.
 		 *
-		 * @param array $url
+		 * @param array $args
 		 */
 		return apply_filters( $this->identifier . '_query_args', $args );
 	}
@@ -121,7 +121,7 @@ abstract class WP_Async_Request {
 		$url = admin_url( 'admin-ajax.php' );
 
 		/**
-		 * Filters the post arguments used during an async request.
+		 * Filters the query URL used during an async request.
 		 *
 		 * @param string $url
 		 */

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -244,7 +244,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * Called when background process has been cancelled.
 	 */
 	protected function cancelled() {
-		do_action( $this->identifier . '_cancelled' );
+		do_action( $this->identifier . '_cancelled', $this->get_chain_id() );
 	}
 
 	/**
@@ -267,7 +267,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * Called when background process has been paused.
 	 */
 	protected function paused() {
-		do_action( $this->identifier . '_paused' );
+		do_action( $this->identifier . '_paused', $this->get_chain_id() );
 	}
 
 	/**
@@ -285,7 +285,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * Called when background process has been resumed.
 	 */
 	protected function resumed() {
-		do_action( $this->identifier . '_resumed' );
+		do_action( $this->identifier . '_resumed', $this->get_chain_id() );
 	}
 
 	/**
@@ -739,7 +739,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * Called when background process has completed.
 	 */
 	protected function completed() {
-		do_action( $this->identifier . '_completed' );
+		do_action( $this->identifier . '_completed', $this->get_chain_id() );
 	}
 
 	/**

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -345,11 +345,14 @@ abstract class WP_Background_Process extends WP_Async_Request {
 		// Don't lock up other requests while processing.
 		session_write_close();
 
+		check_ajax_referer( $this->identifier, 'nonce' );
+
+		// Background process already running.
 		if ( $this->is_processing() ) {
-			// Background process already running.
 			return $this->maybe_wp_die();
 		}
 
+		// Cancel requested.
 		if ( $this->is_cancelled() ) {
 			$this->clear_scheduled_event();
 			$this->delete_all();
@@ -357,6 +360,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 			return $this->maybe_wp_die();
 		}
 
+		// Pause requested.
 		if ( $this->is_paused() ) {
 			$this->clear_scheduled_event();
 			$this->paused();
@@ -364,12 +368,10 @@ abstract class WP_Background_Process extends WP_Async_Request {
 			return $this->maybe_wp_die();
 		}
 
+		// No data to process.
 		if ( $this->is_queue_empty() ) {
-			// No data to process.
 			return $this->maybe_wp_die();
 		}
-
-		check_ajax_referer( $this->identifier, 'nonce' );
 
 		$this->handle();
 


### PR DESCRIPTION
These changes are backwards compatible and should not require any changes to plugins that use WP Background Processing 1.x.

## Chain ID

A Chain ID has been introduced that is automatically generated for each unique chain of background processes.

The Chain ID is a UUIDv4.

The Chain ID is carried across from one dispatched background process to its successor via a simple URL param in order to be as compatible as possible.

To avoid any potential WAF rules that might take offence to a `chain_id` param in the URL, the default `chain_id` param name can be altered via a `{identifier}_chain_id_arg_name` filter.

The Chain ID is exposed to interested parties in a number of ways to allow users of the library to monitor and control the lifecycle of background processes, e.g. to ensure that only one process chain is running.

There is now a `{identifier}_pre_dispatch` filter that is fired before `dispatch` which can be used to cancel a `dispatch` before it happens by returning `true` (for cancel). The 2nd param to the new filter is the `chain_id`.

The existing `{identifier}_paused/resumed/cancelled/completed` actions now include the `chain_id` as a param.

Similarly, the `{identifier}_process_locked` and `{identifier}_process_unlocked` actions now include the `chain_id` as a param.

## Port-forwarded Improvements

Various other improvements have been port-forwarded from use in our plugins.

* A new `get_status` function that works around issues with the options cache exists and is used by `is_paused` and `is_cancelled`.
* The `lock_process` function now takes an optional `$reset_start_time` param that is `true` by default. This is useful when you wish to refresh the lock transient to keep it alive longer without changing the start time held in the record that may be significant to a calculation.
* A public `should_continue` function has been added that wraps the checks of batch limits or status change requests that mean no further processing of the `task` should continue.
* A public `get_identifier` function has been added to make it easier to create hooks in plugins that use the library and validate that the process is of interest.