### PR TITLE
fix(tests): update URL used for downloading wp-content/db.php

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -92,7 +92,7 @@ install_wp() {
 		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
 
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+	download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/refs/heads/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
 install_test_suite() {


### PR DESCRIPTION
Looks like GitHub has broken the use of the old `raw.github.com` download URL, which broke the download of `db.php` for our unit tests install.

This PR simply switches in the current raw URL for the same file.